### PR TITLE
Show all activities for admins (issue #32)

### DIFF
--- a/src/assets/js/lib/api.js
+++ b/src/assets/js/lib/api.js
@@ -56,7 +56,8 @@ api.getRecentActivities = (cb) => {
     $limit: 10
   };
 
-  if (user.role !== 'organization_admin') {
+  // Admin can see all activities from every department
+  if (['super_admin', 'organization_admin'].indexOf(user.role) === -1) {
     opts = _.extend(opts, {
       department: user.department
     });

--- a/src/assets/templates/components/settings/user.tag
+++ b/src/assets/templates/components/settings/user.tag
@@ -26,7 +26,7 @@ setting-user
 
   div#change-role-form(class="modal")
     .modal-header
-        h3 Change role of {editingUser.name}
+      h3 Change role of {editingUser.name}
     .divider
     .modal-content
       h5 Role
@@ -82,11 +82,11 @@ setting-user
       $departmentSelector = $changeRoleModal.find('select[name="department"]');
 
       $roleSelector.on('change', () => {
-          let selectedRole = $roleSelector.val();
+        let selectedRole = $roleSelector.val();
       });
     });
 
-    this.users = [];
+    self.users = [];
 
 
     self.loadData = () => {
@@ -96,9 +96,13 @@ setting-user
       });
     };
 
-
     api.getDepartments().then( (res) => {
       self.departments = res.data;
+      self.departments = [{
+        _id: '',
+        name: 'No Department',
+        organization: ''
+      }].concat(self.departments);
       self.loadData();
     });
 
@@ -119,11 +123,12 @@ setting-user
     self.confirmChangeRole = () => {
       let patch = {
         role: $roleSelector.val(),
-        department: [$departmentSelector.val()]
+        department: _.compact([$departmentSelector.val()])
       }
 
+      // Super Admin must has no department
       if( patch.role == "super_admin" ) {
-        delete patch['department'];
+        patch.department = null;
       }
 
       api.updateUser(self.editingUser._id, patch).then( (res) => {

--- a/src/lib/route/default.js
+++ b/src/lib/route/default.js
@@ -77,6 +77,7 @@ router.get('/settings/user', auth({ admin: true }), (req, res, next) => {
     return;
   }
   const availableRoles = [
+    { id: 'public_relations', name: 'Public Relations' },
     { id: 'department_head', name: 'Department Head' },
     { id: 'organization_admin', name: 'Admin' }
   ];


### PR DESCRIPTION
- Removed department filter from activity API for admins
- Able to remove department from user
- Auto remove department when user's role changed to `super_admin`
- Added `public_relations` role to change role dropdown list